### PR TITLE
INFRA-2333 Temporary resolve release bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,6 @@
     </scm>
 
     <distributionManagement>
-        <repository>
-            <id>bintray</id>
-            <url>https://api.bintray.com/maven/urbanairship/open-source/sarlacc-pit/;publish=1</url>
-        </repository>
         <snapshotRepository>
             <id>snapshots</id>
             <url>gs://airship-maven-snapshots/snapshots</url>

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,26 @@
     </scm>
 
     <distributionManagement>
+        <repository>
+            <id>releases</id>
+            <url>gs://airship-maven-artifacts/releases</url>
+        </repository>
         <snapshotRepository>
             <id>snapshots</id>
             <url>gs://airship-maven-snapshots/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>airship-releases</id>
+            <url>gs://airship-maven-artifacts/releases</url>
+        </repository>
+        <repository>
+            <id>airship-thirdparty</id>
+            <url>gs://airship-maven-artifacts/thirdparty</url>
+        </repository>
+    </repositories>
 
     <build>
         <extensions>


### PR DESCRIPTION
by removing the bintray repository from parent pom. 

https://urbanairship.atlassian.net/browse/INFRA-2333

INFRA-2333 attempted to help introduce a deployable open source jar that also supported our gcs maven. We are having troubles with the credentials for bintray so as a very temporary step we are removing that repository from the pom. 

This change should result in releases going to our standard gcs repository instead of the open source one.

Example of failing build. 
https://jenkins.airship.com/job/sarlacc-pit/8/com.urbanairship$sarlacc-pit/console