### PR TITLE
Update storage to a non deprecated version ahead of the Nov removal.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.1.1</version>
+                <version>1.2</version>
             </dependency>
 
             <dependency>
@@ -214,7 +214,7 @@
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client-jackson2</artifactId>
-                <version>1.21.0</version>
+                <version>1.24.1</version>
             </dependency>
 
             <dependency>
@@ -244,19 +244,19 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>19.0</version>
+                <version>20.0</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-storage</artifactId>
-                <version>1.0.1</version>
+                <version>1.39.0</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-core</artifactId>
-                <version>1.0.1</version>
+                <version>1.39.0</version>
             </dependency>
 
             <!-- Test Dependencies -->


### PR DESCRIPTION
https://urbanairship.atlassian.net/browse/ORC-1679

Output of mvn dependency:tree -Dincludes=com.google.apis,com.google.cloud,com.google*:*client*:,com.urbanairship.cloud,org.apache.beam

>[INFO] Reactor Build Order:
[INFO] 
[INFO] sarlacc-pit                                                        [pom]
[INFO] sarlacc-client                                                     [jar]
[INFO] sarlacc-gcloud                                                     [jar]
[INFO] 
[INFO] --------------------< com.urbanairship:sarlacc-pit >--------------------
[INFO] Building sarlacc-pit 4.1.1-SNAPSHOT                                [1/3]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.10:tree (default-cli) @ sarlacc-pit ---
[INFO] 
[INFO] ------------------< com.urbanairship:sarlacc-client >-------------------
[INFO] Building sarlacc-client 4.1.1-SNAPSHOT                             [2/3]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.10:tree (default-cli) @ sarlacc-client ---
[INFO] 
[INFO] ------------------< com.urbanairship:sarlacc-gcloud >-------------------
[INFO] Building sarlacc-gcloud 4.1.1-SNAPSHOT                             [3/3]
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from airship: gs://airship-maven-artifacts/releases/com/urbanairship/sarlacc-client/4.1.1-SNAPSHOT/maven-metadata.xml
Downloading from airship-releases: gs://airship-maven-artifacts/releases/com/urbanairship/sarlacc-client/4.1.1-SNAPSHOT/maven-metadata.xml
Downloading from airship-thirdparty: gs://airship-maven-artifacts/thirdparty/com/urbanairship/sarlacc-client/4.1.1-SNAPSHOT/maven-metadata.xml
Downloading from central: https://repo.maven.apache.org/maven2/com/urbanairship/sarlacc-client/4.1.1-SNAPSHOT/maven-metadata.xml
Sep 23, 2020 1:49:29 PM com.vorstella.shade.com.google.auth.oauth2.DefaultCredentialsProvider warnAboutProblematicCredentials
WARNING: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/.
[INFO] 
[INFO] --- maven-dependency-plugin:2.10:tree (default-cli) @ sarlacc-gcloud ---
[INFO] com.urbanairship:sarlacc-gcloud:jar:4.1.1-SNAPSHOT
[INFO] +- com.google.cloud:google-cloud-storage:jar:1.39.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core-http:jar:1.39.0:compile
[INFO] |  |  +- com.google.oauth-client:google-oauth-client:jar:1.24.1:compile
[INFO] |  |  +- com.google.api-client:google-api-client:jar:1.24.1:compile
[INFO] |  |  +- com.google.http-client:google-http-client-appengine:jar:1.24.1:compile
[INFO] |  |  +- com.google.http-client:google-http-client-jackson:jar:1.24.1:compile
[INFO] |  |  \- com.google.http-client:google-http-client-jackson2:jar:1.24.1:compile
[INFO] |  \- com.google.apis:google-api-services-storage:jar:v1-rev135-1.24.1:compile
[INFO] \- com.google.cloud:google-cloud-core:jar:1.39.0:compile
[INFO]    \- com.google.http-client:google-http-client:jar:1.24.1:compile
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for sarlacc-pit 4.1.1-SNAPSHOT:
[INFO] 
[INFO] sarlacc-pit ........................................ SUCCESS [  0.602 s]
[INFO] sarlacc-client ..................................... SUCCESS [  0.058 s]
[INFO] sarlacc-gcloud ..................................... SUCCESS [  1.651 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.527 s
[INFO] Finished at: 2020-09-23T13:49:30-07:00
[INFO] ------------------------------------------------------------------------
